### PR TITLE
Make use of the "field init shorthand" syntax for cleaner code and small aesthetic change.

### DIFF
--- a/src/bin/autojump/main.rs
+++ b/src/bin/autojump/main.rs
@@ -105,8 +105,8 @@ pub fn main() {
             flag_complete: app.is_present("complete"),
             flag_purge: app.is_present("purge"),
             flag_add: app.value_of("add").map(|x| x.to_owned()),
-            flag_increase: flag_increase,
-            flag_decrease: flag_decrease,
+            flag_increase,
+            flag_decrease,
             flag_stat: app.is_present("stat"),
         }
     };

--- a/src/bin/autojump/query.rs
+++ b/src/bin/autojump/query.rs
@@ -106,11 +106,11 @@ fn prepare_query<'a>(
     };
 
     Query::Execute(QueryConfig {
-        needles: needles,
-        check_existence: check_existence,
-        index: index,
-        count: count,
-        use_fallback: use_fallback,
+        needles,
+        check_existence,
+        index,
+        count,
+        use_fallback,
     })
 }
 

--- a/src/bin/autojump/stat.rs
+++ b/src/bin/autojump/stat.rs
@@ -32,7 +32,7 @@ pub fn print_stat(config: &Config) {
         }
     }
 
-    println!("________________________________________\n");
+    println!("⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯\n");
     println!("{:.0}:\t total weight", weight_sum.floor());
     println!("{}:\t number of entries", entries.len());
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -71,8 +71,8 @@ impl Config {
 
         Config {
             prefix: data_home,
-            data_path: data_path,
-            backup_path: backup_path,
+            data_path,
+            backup_path,
         }
     }
 }

--- a/src/data/entry.rs
+++ b/src/data/entry.rs
@@ -15,7 +15,7 @@ impl Entry {
     {
         Entry {
             path: path.into(),
-            weight: weight,
+            weight,
         }
     }
 }

--- a/src/matcher/fuzzy.rs
+++ b/src/matcher/fuzzy.rs
@@ -20,10 +20,7 @@ impl<'a> FuzzyMatcher<'a> {
     }
 
     pub fn new(needle: &'a str, threshold: f64) -> FuzzyMatcher<'a> {
-        FuzzyMatcher {
-            needle: needle,
-            threshold: threshold,
-        }
+        FuzzyMatcher { needle, threshold }
     }
 
     pub fn filter_path<'p, P>(&'a self, paths: &'p [P]) -> impl iter::Iterator<Item = &'p P> + 'a

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -57,9 +57,9 @@ impl<'a> Matcher<'a> {
             re_based::prepare_regex(&needles, re_based::re_match_consecutive, ignore_case);
 
         Matcher {
-            fuzzy_matcher: fuzzy_matcher,
-            re_anywhere: re_anywhere,
-            re_consecutive: re_consecutive,
+            fuzzy_matcher,
+            re_anywhere,
+            re_consecutive,
         }
     }
 


### PR DESCRIPTION
[_Field init shorthand_ Book section](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#using-the-field-init-shorthand-when-variables-and-fields-have-the-same-name).

It looks like this in my terminal (Alacritty).
- New
![2020-08-17_17-08-1597704225](https://user-images.githubusercontent.com/28630268/90452254-55b64d80-e0b3-11ea-8beb-d1436fbdd756.png)

- Old
![2020-08-17_17-08-1597704186](https://user-images.githubusercontent.com/28630268/90452260-5a7b0180-e0b3-11ea-93f9-94ed6a583f46.png)
