### PR TITLE
Update Cargo.toml version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autojump"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Wang Xuerui <git@xen0n.name>"]
 description = "A Rust port and drop-in replacement of autojump"
 repository = "https://github.com/xen0n/autojump-rs"


### PR DESCRIPTION
It would be nice if a new release could be tagged 0.5.1 with the correct version in the tarball too, please.