### PR TITLE
fix boolean flags

### DIFF
--- a/src/bin/autojump/main.rs
+++ b/src/bin/autojump/main.rs
@@ -52,17 +52,20 @@ pub fn main() {
             .arg(
                 Arg::new("complete")
                     .long("complete")
+                    .action(ArgAction::SetTrue)
                     .help("used for tab completion"),
             )
             .arg(
                 Arg::new("purge")
                     .long("purge")
+                    .action(ArgAction::SetTrue)
                     .help("remove non-existent paths from database"),
             )
             .arg(
                 Arg::new("stat")
                     .short('s')
                     .long("stat")
+                    .action(ArgAction::SetTrue)
                     .help("show database entries and their key weights"),
             )
             .arg(
@@ -103,12 +106,12 @@ pub fn main() {
             arg_dir: app
                 .get_many::<String>("dir")
                 .map_or(vec![], |x| x.cloned().collect()),
-            flag_complete: app.contains_id("complete"),
-            flag_purge: app.contains_id("purge"),
+            flag_complete: app.get_flag("complete"),
+            flag_purge: app.get_flag("purge"),
             flag_add: app.get_one::<String>("add").cloned(),
             flag_increase,
             flag_decrease,
-            flag_stat: app.contains_id("stat"),
+            flag_stat: app.get_flag("stat"),
         }
     };
     let config = Config::defaults();


### PR DESCRIPTION
The command line arguments `--complete`, `--purge` and `--stat` have been configured in the original autojump implementation with `action="store_true"`, compare e.g. 

https://github.com/wting/autojump/blob/06e082c91805cb022900819b2e0881eeae780d58/bin/autojump#L120

To achieve the same here i added an `ArgAction::SetTrue` and changed `app.contains_id` to `app.get_flag` for these options. Now for me the [fzf integration code snippet](https://github.com/junegunn/fzf/wiki/Examples#autojump) works again which makes use of the `-s` option and was broken with `autojump-rs`. For me autocompletion also seems to work now, so I think #213 should also be fixed by this PR.